### PR TITLE
fix udev compile

### DIFF
--- a/eudev/compile.sh
+++ b/eudev/compile.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
 [ -f all/usr/bin/kmod -a -f all/usr/bin/udevadm ] && exit 0
+mkdir all
+sudo chown 1000 -R all
 docker run --rm -t -v $PWD/src:/input -v $PWD/all:/output fbelavenuto/syno-compiler bash /input/docker-compile.sh
 sudo chown `id -u`:`id -g` -R all

--- a/eudev/src/docker-compile.sh
+++ b/eudev/src/docker-compile.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
+# test output write allowed before start
+mkdir /output/test || exit 1
+rmdir /output/test
+
 git clone --single-branch https://github.com/kmod-project/kmod.git /tmp/kmod
 cd /tmp/kmod
 git checkout v30
 patch -p1 < /input/kmod.patch
 ./autogen.sh
 ./configure CFLAGS='-O2' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib --enable-tools --disable-manpages --disable-python --without-zstd --without-xz --without-zlib --without-openssl
-make
+make all
 sudo make install
 make DESTDIR=/output install
 git clone --single-branch https://github.com/eudev-project/eudev.git /tmp/eudev


### PR DESCRIPTION
Hi,
The udev compilation problem comes from the image latest of syno-compiler.
https://hub.docker.com/layers/fbelavenuto/syno-compiler/latest/images/sha256-808427763f7cbd53713cf8bb8b3f338ecc6a1814aeadfb8f8c378040cca32787?context=explore
Indeed, in this docker for some reason sudo command is absent!

Here is a regenerated version which sudo command is present.
https://hub.docker.com/layers/jimmygalland/syno-compiler/7.1/images/sha256-aae152a953bec7367e45f2c79065ca03ed9ebb9a7156ac5e075a9e9faad8a14e?context=explore

Also I send you some modifications for the compilation scripts, under conditions may have write right errors with the output directory.

And here is a link to a release with the udev binaries inside
https://github.com/jimmyGALLAND/arpl-addons/releases/tag/v2.90-jimmygalland

Thank you for your job
Have a good day